### PR TITLE
Use https://api.lbry.tv/api/v1/proxy by default

### DIFF
--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <settings>
   <category label="30000">
-    <setting id="lbry_api_url" type="text" option="urlencoded" label="30005" default="http://localhost:5279"/>
+    <setting id="lbry_api_url" type="text" option="urlencoded" label="30005" default="https://api.lbry.tv/api/v1/proxy"/>
     <setting id="nsfw" type="bool" label="30001" default="false"/>
     <setting id="items_per_page" type="number" label="30002" default="20"/>
     <setting type="lsep" label="30003"/>


### PR DESCRIPTION
Closes #3.

For more information, please see https://github.com/lbryio/lbrytv/issues/295#issuecomment-753675059.